### PR TITLE
Trim header value

### DIFF
--- a/response.go
+++ b/response.go
@@ -62,7 +62,7 @@ func (r Response) getHeaderData() map[string]string {
       i = len(r.resp)
     } else {
       x := strings.Split(r.resp[i], ":")
-      results[x[0]] = x[1]
+      results[x[0]] = strings.TrimSpace(x[1])
     }
   }
   return results


### PR DESCRIPTION
Fix header value with int type
Example:
`Content-Length: 70`
on previous version it'll generate error
`http: invalid Content-Length of " 70"`
